### PR TITLE
Move the TEPP output variable to the TEPP code block

### DIFF
--- a/components/mosart/src/riverroute/RtmHistFlds.F90
+++ b/components/mosart/src/riverroute/RtmHistFlds.F90
@@ -213,14 +213,6 @@ contains
       call RtmHistAddfld (fname='TEMP_QSUB', units='Kelvin',  &
            avgflag='A', long_name='Temperature of subsurface runoff', &
            ptr_rof=rtmCTL%templand_Tqsub_nt1)
-
-      call RtmHistAddfld (fname='QTHERM_FROM_CIME', units='m3/s',  &
-           avgflag='A', long_name='Thermal discharge Q ', &
-           ptr_rof=rtmCTL%QTHERM)
-
-      call RtmHistAddfld (fname='TTHERM_FROM_CIME', units='Kelvin',  &
-           avgflag='A', long_name='Thermal effluent temperature ', &
-           ptr_rof=rtmCTL%TTHERM)
     
       call RtmHistAddfld (fname='TEMP_TRIB', units='Kelvin',  &
            avgflag='A', long_name='Water temperature of tributary channels', &
@@ -269,6 +261,12 @@ contains
         call RtmHistAddfld (fname='THERM_WDEMAND', units='%',  &
            avgflag='A', long_name='Percent of TEPP met water demand', &
            ptr_rof=rtmCTL%metThermDem)	
+        call RtmHistAddfld (fname='QTHERM_FROM_CIME', units='m3/s',  &
+           avgflag='A', long_name='Thermal discharge Q ', &
+           ptr_rof=rtmCTL%QTHERM)
+        call RtmHistAddfld (fname='TTHERM_FROM_CIME', units='Kelvin',  &
+           avgflag='A', long_name='Thermal effluent temperature ', &
+           ptr_rof=rtmCTL%TTHERM)
       
       end if
     end if     


### PR DESCRIPTION
Moving the code that writes out TEPP related variables to the code block that is executed only when TEPP module is turned on.